### PR TITLE
Updated manifest `install.yml`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Dr. Kubez is a tool to test, diagnose and load k8s clusters.
 To run it in your cluster
 
 ``` 
-kubectl apply -f kubez.yaml
+kubectl apply -f https://raw.githubusercontent.com/middlewaregruppen/kubez/master/install.yaml
 ```
 
 ##  Things you can do with it today

--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,92 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubez
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - pods/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - namespaces
+  - namespaces/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - create
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubez
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubez
+subjects:
+- kind: ServiceAccount
+  name: kubez
+  namespace: kubez
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubez
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubez
+spec:
+  type: NodePort
+  selector:
+    app: kubez-app
+  ports:
+  - nodePort: 31503
+    port: 3000
+    targetPort: http
+    name: http
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,6 +106,8 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 3000
+          protocol: TCP
+          name: http
         resources:
           requests:
             cpu: 300m
@@ -25,19 +115,5 @@ spec:
           limits:
             cpu: 300m
             memory: 100Mi
-...
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kubez
-spec:
-  type: NodePort
-  selector:
-    app: kubez-app
-  ports:
-  - nodePort: 31503
-    port: 3000
-    targetPort: 3000
-...
-
+      serviceAccount: kubez
+      serviceAccountName: kubez


### PR DESCRIPTION
I've added some stuff to `install.yml` in order for kubez to have enough privileges to create deployments/replicasets/pods for the 'Load Kubernetes' feature. 

Also,  swapped input parameter to the `kubectl apply` in README for an URL. So users don't have to clone the repo in order to deploy kubez in their clusters.