### PR TITLE
On app load throwing`undefined` errors due to uninitialised properties

### DIFF
--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -93,19 +93,18 @@ export default {
   props: {
     source: String
   },
-
   computed: {
        hostname () {
       return this.$store.state.info.hostname
     },
-      namespace (){
-        return this.$store.state.info.k8sstats.namespace
-      }
-      ,
-
+    namespace (){
+      return this.$store.state.info.k8sstats.namespace
+    },
     connectionStatus: function() {
        var c = {
-        loading: false
+        loading: false,
+        colour: '',
+        code: '',
       };
       switch (this.$store.getters.status) {
         case 200:
@@ -114,22 +113,18 @@ export default {
           break
         case -1:
           c.code = ""
-          return 
-          
-
+          break
         default:
           c.colour = "red"
           c.code = this.$store.getters.status
+          break
       }
       return c;
     }
   },
-
   data: () => ({
     drawer: null,
-
   }),
-
   created() {
     this.$vuetify.theme.dark = true;
   }

--- a/web/frontend/src/components/K8SLoad.vue
+++ b/web/frontend/src/components/K8SLoad.vue
@@ -129,6 +129,7 @@ export default {
   },
   data: () => ({
     namespaces: "",
+    namespace: "",
     deployments: "1",
     pods: "1",
     reqCPU: "0",


### PR DESCRIPTION
Switch loop causing unpredictable behaviour due to not having break clause in component `App`. Also initialised returned object with fields for clarity. Error was:
```
vue.runtime.esm.js?2b0e:619 [Vue warn]: Error in render: "TypeError: Cannot read property 'colour' of undefined"

found in

---> <App> at src/App.vue
       <Root>
```

Fixed so that component `K8SLoad` has initialised properties on app load. Error in console was:
```
vue.runtime.esm.js?2b0e:619 [Vue warn]: Property or method "namespace" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.

found in

---> <K8SLoad>
       <VCard>
         <ComputeStats> at src/views/ComputeStats.vue
           <VContent>
             <VApp>
               <App> at src/App.vue
                 <Root>
```