### PR TITLE
WIP: Immutable Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
+FROM golang:alpine AS go-build
+COPY . /build
+WORKDIR /build/
+RUN apk add --no-cache --update git make ca-certificates \
+&&  make
+
+FROM node:10 AS npm-build
+COPY web/frontend/ /build
+WORKDIR /build/
+RUN npm install \
+&&  NODE_ENV=production npm run build  
+
 FROM scratch
-
-COPY out/* /
-COPY web/frontend/dist  /web/frontend/dist
-
-CMD ["/kubez"]
+LABEL maintaner="@middlewaregruppen (github.com/middlewaregruppen)"
+COPY --from=go-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=go-build /build/bin/kubez-linux-amd64 /go/bin/kubez
+COPY --from=npm-build /build/dist /web/frontend/dist
+ENTRYPOINT ["/go/bin/kubez"]


### PR DESCRIPTION
* Dockerfile can be used to build container image as-is. No need to build the frontend and server first.
* This PR is ment to enchance how the Docker image is published by using autobuild functionality in Docker Hub

Checks before merge
- [x] Triggers autobuilds in Docker Hub on tagged commits on master